### PR TITLE
fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,13 @@ jobs:
   release-pypi:
     name: release-pypi
     runs-on: ubuntu-latest
+    environment: main
 
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Build artifacts
         run: |
           pip install build


### PR DESCRIPTION
- check-py38 support
- add environment to .github/workflows/release.yml
