### PR TITLE
change verbosity level to normal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,19 @@ on:
       - "*.md"
 
 jobs:
+  Type Checking:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: pip install hatch
+      - uses: actions/cache@v3
+        id: hatch-cache
+        with:
+          # cache to runner
+          path: hatch-cache
+          key: ${{ hashFiles('pyproject.toml') }}
+      - name: Run pytype
+        run: hatch --cache-dir hatch-cache pytype src
   Coverage:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
       - "*.md"
 
 jobs:
-  Type Checking:
+  Type-Checking:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           path: hatch-cache
           key: ${{ hashFiles('pyproject.toml') }}
       - name: Run pytype
-        run: hatch --cache-dir hatch-cache pytype src
+        run: hatch --cache-dir hatch-cache run pytype src
   Coverage:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           path: hatch-cache
           key: ${{ hashFiles('pyproject.toml') }}
       - name: Run pytype
-        run: hatch --cache-dir hatch-cache run pytype src
+        run: hatch --cache-dir hatch-cache run static:pytype src
   Coverage:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         name: pytype
         language: system
         types: [python]
-        entry: hatch env run -e typecheck pytype
+        entry: hatch env run pytype
   # - repo: https://github.com/pre-commit/mirrors-mypy
   #   rev: v1.7.0
   #   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+ci:
+  skip: ["pytype"]
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
@@ -15,9 +17,13 @@ repos:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.0
+  - repo: https://github.com/google/pytype
+    rev: 2023.11.29
     hooks:
-      - id: mypy
-        additional_dependencies:
-          - types-toml
+      - id: pytype
+  # - repo: https://github.com/pre-commit/mirrors-mypy
+  #   rev: v1.7.0
+  #   hooks:
+  #     - id: mypy
+  #       additional_dependencies:
+  #         - types-toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,10 +17,13 @@ repos:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]
 
-  - repo: https://github.com/google/pytype
-    rev: 2023.11.29
+  - repo: local
     hooks:
       - id: pytype
+        name: pytype
+        language: system
+        types: [python]
+        entry: hatch env run -e typecheck pytype
   # - repo: https://github.com/pre-commit/mirrors-mypy
   #   rev: v1.7.0
   #   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         name: pytype
         language: system
         types: [python]
-        entry: hatch env run pytype
+        entry: hatch run static:pytype
   # - repo: https://github.com/pre-commit/mirrors-mypy
   #   rev: v1.7.0
   #   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,8 @@ scripts.test = "pytest {args:tests}"
 scripts.test-cov = "pytest --cov=src {args:tests}"
 scripts.cov = "hatch run test-cov {args:tests} --cov-report=xml"
 
-[tool.hatch.envs.typecheck]
+[tool.hatch.envs.static]
 dependencies = ["pytype"]
-scripts.pytype = "pytype {args:src}"
 
 
 [tool.hatch.envs.docs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "pytest-cov>=4.0.0",
     "python-dotenv[cli]",
     "toml",
+    "pytype",
 ]
 
 scripts.test = "pytest {args:tests}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,12 +34,16 @@ dependencies = [
     "pytest-cov>=4.0.0",
     "python-dotenv[cli]",
     "toml",
-    "pytype",
 ]
 
 scripts.test = "pytest {args:tests}"
 scripts.test-cov = "pytest --cov=src {args:tests}"
 scripts.cov = "hatch run test-cov {args:tests} --cov-report=xml"
+
+[tool.hatch.envs.typecheck]
+dependencies = ["pytype"]
+scripts.commit = "git commit"
+
 
 [tool.hatch.envs.docs]
 dependencies = ["mkdocs>=1.1", "mkdocs-material>=6.2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ scripts.cov = "hatch run test-cov {args:tests} --cov-report=xml"
 
 [tool.hatch.envs.typecheck]
 dependencies = ["pytype"]
-scripts.commit = "git commit"
+scripts.pytype = "pytype {args:src}"
 
 
 [tool.hatch.envs.docs]

--- a/src/pdm_dotenv/__init__.py
+++ b/src/pdm_dotenv/__init__.py
@@ -10,11 +10,12 @@ import dotenv
 from pdm.project import ConfigItem, Project
 from pdm.signals import pre_invoke
 from pdm.core import Core
+from pdm.termui import Verbosity
 
 
 def load_dotenv(project: Project, **_: Any) -> None:
     dotenv_path = project.root / project.config["dotenv.path"]
-    project.core.ui.echo(f"Loading dotenv file {dotenv_path}")
+    project.core.ui.echo(f"Loading dotenv file {dotenv_path}", verbosity=Verbosity.NORMAL)
     dotenv.load_dotenv(dotenv_path)
 
 

--- a/src/pdm_dotenv/__init__.py
+++ b/src/pdm_dotenv/__init__.py
@@ -15,7 +15,7 @@ from pdm.termui import Verbosity
 
 def load_dotenv(project: Project, **_: Any) -> None:
     dotenv_path = project.root / project.config["dotenv.path"]
-    project.core.ui.echo(f"Loading dotenv file {dotenv_path}", verbosity=Verbosity.NORMAL)
+    project.core.ui.echo(f"Loading dotenv file {dotenv_path}", err=True, verbosity=Verbosity.NORMAL)
     dotenv.load_dotenv(dotenv_path)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,46 +1,41 @@
 from pdm.cli.actions import textwrap
+import _pytest
+import pytest
+import typing
 from pdm.project import Project
+from pdm.pytest import RunResult
 import pathlib
 import tempfile
-from typing import TYPE_CHECKING, Tuple, List
+from typing import TYPE_CHECKING, List
 import toml
 
 if TYPE_CHECKING:
     from pdm.pytest import PDMCallable
 
 
-def dotenv_set(file: pathlib.Path, key: str, val: str) -> List[str]:
-    return [
-        "run",
-        "dotenv",
-        f"--file={file}",
-        "set",
-        key,
-        val,
-    ]
+def assert_in_env(
+    pdm_in_project: typing.Callable[[List[str]], RunResult],
+    key: str,
+    val: str,
+) -> None:
+    with tempfile.TemporaryDirectory() as td:
+        fp = pathlib.Path(td)
+        out_path = fp / "foo.txt"
+        out_path.touch()
+        cmd = [
+            "run",
+            "python",
+            "-c",
+            textwrap.dedent(
+                f"""
+                import os, pathlib
+                pathlib.Path({str(out_path)!r}).write_text(os.environ.get({key!r}, ""))
+                """
+            ),
+        ]
+        pdm_in_project(cmd)
 
-
-def check_env(project: Project, pdm: "PDMCallable", environ: Tuple[Tuple[str, str]]) -> None:
-    for key, val in environ:
-        with tempfile.TemporaryDirectory() as td:
-            fp = pathlib.Path(td) / "foo.txt"
-            fp.touch()
-            pdm(
-                [
-                    "run",
-                    "python",
-                    "-c",
-                    textwrap.dedent(
-                        f"""
-                        import os, pathlib
-                        pathlib.Path({str(fp)!r}).write_text(os.environ.get({key!r}, ""))
-                        """
-                    ),
-                ],
-                strict=True,
-                obj=project,
-            )
-            assert val == fp.read_text().strip()
+        assert val == (fp / "foo.txt").read_text().strip()
 
 
 def test_build(project: Project, pdm: "PDMCallable") -> None:
@@ -82,33 +77,64 @@ def test_build(project: Project, pdm: "PDMCallable") -> None:
     assert (project.root / "dist" / f"foo-{exp_ver}-py3-none-any.whl").exists()
 
 
-def test_happy_path(project: Project, pdm: "PDMCallable") -> None:
-    environ = (("FOO_BAR_BAZ", "hello"),)
-    for key, val in environ:
-        pdm(
-            dotenv_set(project.root / ".env", key, val),
-            obj=project,
-            strict=True,
-        )
+def pdm_in_project_factory(pdm: "PDMCallable", project: Project) -> RunResult:
+    def wrapped(args: List[str]) -> RunResult:
+        return pdm(args, strict=True, obj=project)
 
-    check_env(project, pdm, environ)
+    return wrapped
 
 
-def test_different_file(project: Project, pdm: "PDMCallable") -> None:
-    environ = (("FOO_BAR_BAZ", "hello"),)
-    for key, val in environ:
-        pdm(
-            dotenv_set(project.root / ".foo.env", key, val),
-            obj=project,
-            strict=True,
-        )
-    pdm(
+def dotenv_set(pdm_in_project, key, val, dotenv):
+    pdm_in_project(
         [
-            "config",
-            "dotenv.path",
-            ".foo.env",
+            "run",
+            "dotenv",
+            f"--file={dotenv}",
+            "set",
+            key,
+            val,
         ],
-        obj=project,
     )
 
-    check_env(project, pdm, environ)
+
+@pytest.mark.parametrize("quiet", (True, False))
+def test_quiet(project: Project, pdm: "PDMCallable", quiet: bool) -> None:
+    dotenv_set(pdm_in_project_factory(pdm, project), "foo", "bar", dotenv=project.root / ".env")
+
+    cmd = ["run"]
+    if quiet:
+        cmd.append("--quiet")
+    cmd.extend(["python", "-c", "print()"])
+
+    result = pdm(cmd, strict=True, obj=project)
+    loading_snippet = "Loading dotenv file"
+    assert (loading_snippet in result.stderr) != quiet
+    assert loading_snippet not in result.stdout
+
+
+ENVIRON = (("FOO_BAR_BAZ", "hello"),)
+
+
+@pytest.fixture(params=[".env", "foo.env", None])
+def dotenv_file(request: _pytest.fixtures.SubRequest, project: Project, pdm: "PDMCallable") -> str:
+    pdm_in_project = pdm_in_project_factory(pdm, project)
+
+    for key, val in ENVIRON:
+        dotenv_set(pdm_in_project, key, val, dotenv=project.root / (request.param or ".env"))
+
+    if request.param:
+        pdm_in_project(
+            [
+                "config",
+                "dotenv.path",
+                request.param,
+            ],
+        )
+
+    return request.param
+
+
+def test_happy_path(dotenv_file, project: Project, pdm: "PDMCallable") -> None:
+    pdm_in_project = pdm_in_project_factory(pdm, project)
+    for key, val in ENVIRON:
+        assert_in_env(pdm_in_project, key, val)


### PR DESCRIPTION
So I had the confirmation in [pdm#2460](https://github.com/pdm-project/pdm/pull/2460) that the verbosity level is actually normal, so it's up to pdm-dotenv to change its verbosity level. With this change, the message still shows up on normal invocation and doesn't when `--quiet` is passed to pdm:

```
➜  pdm venv activate
Loading dotenv file /Users/mathieu/dev/pdm-dotenv/.env
source '/Users/mathieu/Library/Application Support/pdm/venvs/pdm-dotenv-LmuwbYeK-3.10/bin/activate'
➜  pdm venv activate --quiet
source '/Users/mathieu/Library/Application Support/pdm/venvs/pdm-dotenv-LmuwbYeK-3.10/bin/activate'
```